### PR TITLE
Partners Feature V1

### DIFF
--- a/src/AlphaConsole.js
+++ b/src/AlphaConsole.js
@@ -32,6 +32,7 @@ var serverInfo = require(serverInfoPath).serverInfo;
 client.on('ready', () => {
     require('./events/ready.js').run(client, serverInfo, sql, AllowedLinksSet, AutoResponds, Commands, Events, SwearWordsSet, blackListedWords);
     require('./events/TitleCleanUp.js').run(client, serverInfo, sql);
+    require('./events/updatePartners.js').run(client, serverInfo, sql);
 });
 
 //New member joins
@@ -66,7 +67,7 @@ client.on('messageDelete', (message) => {
 
 //React has been added
 client.on('messageReactionAdd', (reaction, user) => {
-    require('./events/messageReactionAdd.js').run(client, serverInfo, reaction, user);
+    require('./events/messageReactionAdd.js').run(client, serverInfo, reaction, user, sql);
 });
 
 //Message Updated - Run checks for links / blacklisted. Spam check not needed since it's not a new message.
@@ -277,6 +278,11 @@ async function messageProcess(message){
              
             else if (args[0].toLowerCase() == "!betaids") {
                 require('./cmds/betaids.js').run(client, serverInfo, message, args, sql)
+            }
+            
+            //Admin partner command - only works in serverInfo.editPartnerChannel
+            else if (args[0].toLowerCase() == "!partner"){
+                require('./cmds/partner.js').run(client, serverInfo, sql, message, args)
             }
 
             //For commands with 2 args.

--- a/src/cmds/addPartner.js
+++ b/src/cmds/addPartner.js
@@ -1,0 +1,143 @@
+const Discord = require('discord.js');
+
+module.exports = {
+    title: "add partner",
+    perms: "Admin",
+    commands: ["!addPartner <Partner Type> <Partner Name>"],
+    description: ["Adds a partner, note this can only be used in the #add-partner channel. To view Partner Types run !viewPartnerTypes"],
+
+    run: async (client, serverInfo, sql, message, args) => {
+        if (message.channel.id != serverInfo.addPartnerChannel) return; //Ignore it if it's not in the add partner channel
+
+        if (hasRole(message.member, "Admin")) { // Ensure this user is permitted to do this,
+            // Check arguments
+            if (args.length < 3) {
+                const embed = new Discord.MessageEmbed()
+                    .setColor([255, 255, 0])
+                    .setTitle('You must specify both a Partner Type and a Partner Name!')
+                return message.channel.send(embed)
+            }
+
+            var type = args[1].toLowerCase();
+            var name = args.slice(2).join(" ");
+            console.log(name);
+
+            var amount = 50; // Max amount of messages to check for (can be up to 100)
+
+            //Delete users message
+            message.delete()
+                .then(dmes => {
+                    message.channel.messages.fetch({ limit: amount })
+                        .then(collectedMessages => {
+                            // All good in the hood format this boi
+                            var data = {};
+                            var messages = [];
+                            var mesArray = Array.from(collectedMessages.values());
+                            // Run through in reverse order so that we can remove messages without running into issues looking for nonexistent messages
+                            for (var i = (mesArray.length - 1); i >= 0; i--) {
+                                var cmessage = mesArray[i];
+
+                                // Check if this message has a file
+                                if (cmessage.attachments !== undefined && Array.from(cmessage.attachments).length > 0 && !cmessage.author.bot) {
+                                    var messageImage = {};
+                                    var att = Array.from(cmessage.attachments);
+                                    messageImage.type = "file";
+                                    messageImage.content = att[0][1].url;
+                                    messages.push(messageImage);
+                                }
+
+                                // Check if this message has text, will split up file & text into separate message entries if both exist (not !addpartner is incase delete doesn't delete it quick enough)
+                                if (cmessage.content !== undefined && cmessage.content.length > 0 && !cmessage.author.bot && !cmessage.toLowerCase.content.contains("!addpartner")) {
+                                    var messageText = {};
+                                    messageText.type = "text";
+                                    messageText.content = cmessage.content;
+                                    messages.push(messageText);
+                                }
+
+                                // Delete this message because it's done
+                                cmessage.delete();
+                            }
+                            data.messages = messages;
+
+                            //Check if there is at least one message, or there's no point having the partner in the more info channel
+                            if(messages.length == 0){
+                                const embed = new Discord.MessageEmbed()
+                                .setColor([255, 255, 0])
+                                .setTitle('Partners must have at least one message or image!')
+                                return message.channel.send(embed)
+                            }
+                                
+                            
+                            
+                            console.log(data);
+
+                            // TODO db call here
+                            // Check if partner name exists, if it does  then REEE at user
+
+
+
+
+                            const embed = new Discord.MessageEmbed()
+                                .setColor([255, 255, 0])
+                                .setTitle('Partner Added, Updating the Partners Channel!')
+                            return message.channel.send(embed)
+
+                        })
+                        .catch(console.error);
+                }).catch(console.error);
+        }
+    }
+};
+
+function updatePartnersChannel(client, sql, serverInfo) {
+
+    // Get all types
+
+    // Get all partners
+
+    // For each type
+    // Send type's subheading message, whether it be a file or whatnot
+
+    // For each partner in each type:
+    // send message with whatever content needed
+    // add tracked reaction to message
+    // update message id where oldid = row.id
+    // should be done here
+}
+
+//Functions used to check if a player has the desired role
+function pluck(array) {
+    return array.map(function (item) { return item["name"]; });
+}
+function hasRole(mem, role) {
+    if (pluck(mem.roles).includes(role)) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
+function mysql_real_escape_string(str) {
+    return str.replace(/[\0\x08\x09\x1a\n\r"'\\\%]/g, function (char) {
+        switch (char) {
+            case "\0":
+                return "\\0";
+            case "\x08":
+                return "\\b";
+            case "\x09":
+                return "\\t";
+            case "\x1a":
+                return "\\z";
+            case "\n":
+                return "\\n";
+            case "\r":
+                return "\\r";
+            case "\"":
+            case "'":
+            case "\\":
+            case "%":
+                return char + char; // prepends a backslash to backslash, percent,
+            // and double/single quotes
+        }
+    });
+}

--- a/src/cmds/mute.js
+++ b/src/cmds/mute.js
@@ -25,22 +25,18 @@ module.exports = {
 
                 if(timeArg.includes("d")){ // Days is selected explicitly
                     timeArg = timeArg.replace("d", "");
-                    originalTime = originalTime.replace("d", "");
                     timeunitDisplay = "days"; // Change time unit to days
 
                 }else if(timeArg.includes("h")){ // Hours is selected explicitly
                     timeArg = timeArg.replace("h", "");
-                    originalTime = originalTime.replace("h", "");
                     timeunitDisplay = "hours"; // Change time unit to hours
 
                 }else if(timeArg.includes("m")){ // Minutes is selected explicitly
                     timeArg = timeArg.replace("m", "");
-                    originalTime = originalTime.replace("m", "");
                     timeunitDisplay = "minutes"; // Change time unit to minutes
 
                 }else if(timeArg.includes("s")){ // Seconds is selected explicitly...for some reason...
                     timeArg = timeArg.replace("s", "");
-                    originalTime = originalTime.replace("s", "");
                     timeunitDisplay = "seconds"; // Change time unit to seconds
                 }
 
@@ -59,6 +55,9 @@ module.exports = {
                     .setAuthor(`${timeArg} is not a valid number. Please use 0 for permanent mute`, serverInfo.logo) 
                     return message.channel.send(embed)
                 }
+
+                // Only change this once now, slightly more efficient than replacing also saves 4 lines of code I guess
+                originalTime = timeArg;
 
                 switch(timeunitDisplay){
                     case "days":

--- a/src/cmds/partner.js
+++ b/src/cmds/partner.js
@@ -1,0 +1,673 @@
+const Discord = require('discord.js');
+const amount = 50; // Amount of previous messages to check for when parsing, can be maximum 100. This will be affected by bot responses. So it's best to add more than needed, just incase.
+
+/**
+ *  Note: The bot must send any responses in Embedded Messages, the bot will ignore embeds when parsing messages to be sent to a user or such.
+ *        PS. Make sure to set the emoji in serverInfo.partnerEmoji with an id ^^ ~Nameless
+ * 
+ *        Discord Message IDs are currently 18 digits, which javascript seems to auto round past 15, so the last 2 digits would always round and mess up the id itself.
+ *        This was most evident trying to update, since the id was being stored in an object to pass to the update function. For now I have converted them to strings
+ *        and am passing those which don't seem to round at all. id in partners table thus is stored as text type. ¯\_(ツ)_/¯
+ */
+
+module.exports = {
+    title: "partner",
+    perms: "Admin",
+    commands: ["!partner help"],
+    description: ["Manipulates the partners and partner types for AlphaConsole. Use `!partner help` for more information."],
+
+    run: async (client, serverInfo, sql, message, args) => {
+        if (message.channel.id != serverInfo.editPartnerChannel) return; // Ignore it if it's not in the edit partner channel
+
+        message.delete(500); // Delete the message, we don't need it
+
+        if (hasRole(message.member, "Admin")) { 
+            // Ensure this user is permitted to do this, keep it deleted either way just incase the channel permissions 
+            // get messed up and people somehow figure out the command, makes sure chat doesn't get spammed
+
+            // Check arguments
+            if (args.length < 2) return message.channel.send(getErrorEmbed(serverInfo, "You must specify options! Use `!partner help` for more information!"));
+
+            switch (args[1].toLowerCase()) {
+                // All the below functions will return an embed send, which will in turn be returned from here.
+                case "add":
+                // return Function addPartner
+                return addPartner(client, serverInfo, sql, message, args);
+
+                case "addtype":
+                // return Function addType
+                return addType(client, serverInfo, sql, message, args);
+
+                case "enable":
+                // return Function enablePartner
+                return enablePartner(client, serverInfo, sql, message, args);
+
+                case "disable":
+                // return Function disablePartner
+                return disablePartner(client, serverInfo, sql, message, args);
+
+                case "list":
+                // return Function listPartners
+                return listPartners(client, serverInfo, sql, message, args);
+
+                case "listtypes":
+                // return Function listTypes
+                return listTypes(client, serverInfo, sql, message, args);
+
+                case "setheader":
+                // return Function setHeader
+                return setHeader(client, serverInfo, sql, message, args);
+
+                case "setchannelheader":
+                // return Function setChannelHeader
+                return setChannelHeader(client, serverInfo, sql, message, args);
+
+                case "settypeheader":
+                // return Function setTypeHeader
+                return setTypeHeader(client, serverInfo, sql, message, args);
+
+                case "update":
+                // return Function forceUpdatePartners
+                return forceUpdatePartners(client, serverInfo, sql, message, args);
+
+
+                default: // Also covers help keyword
+                    const embed = new Discord.MessageEmbed()
+                        .setColor([255, 255, 0])
+                        .setAuthor('Partner Command Help:', serverInfo.logo)
+                        .addField("Add Partner", "`!partner add <partner_type> <partner_name>` - Add a Partner, the information to be messaged will be gathered from the Channel up to " + amount + " messages.")
+                        .addField("Add Partner Type", "`!partner addType <partner_type> <subheading_message>` - Add a Partner Category/Type to be shown in the Partner's Channel")
+                        .addField("Enable a Partner", "`!partner enable <partner_name>` (Note: Partners are enabled by default when added!)")
+                        .addField("Disable a Partner", "`!partner disable <partner_name>` - Prevent a Partner from being shown in the Partner's Channel)")
+                        .addField("Show Partners", "`!partner list [enabled|disabled]` - List Partners, optionally you can specify enabled or disabled to filter")
+                        .addField("Show Types", "`!partner listTypes` - Show a list of all the Partner Types")
+                        .addField("Set Channel Header", "`!partner setChannelHeader` - This sets the Partner Channel Header that preceeds all Partners.")
+                        .addField("Set Partner Header", "`!partner setHeader <partner_name>` - Sets the Partner Channel Message for this Partner (The message reacted to)")
+                        .addField("Set Type Header", "`!partner setTypeHeader <type>` - This sets the Partner Type Header that preceeds Partners of this type.")
+                        .addField("Update Partner Channel", "`!partner update` - Force update the Partner Channel")
+                    return message.channel.send(embed)
+            }
+        }
+    }
+};
+
+async function addPartner(client, serverInfo, sql, message, args) {
+    // Check args length
+    // Usage: !partner add <partner_type> <partner_name>
+    // Min Args == 4
+
+    if (args.length < 4) return message.channel.send(getErrorEmbed(serverInfo, "Incorrect Usage: `!partner add <partner_type> <partner_name>`"));
+
+    var type = args[2].toLowerCase();
+    var name = args.slice(3).join(" "); // Join up every other argument past here to allow names with spaces.
+
+    // Check if partner name exists, if it does then don't add anything.
+    // This does not delete messages in the channel outside of the command because of the User Experience,
+    // For instance, a misspelt word of a common partner name would require resending every single message, which would be troublesome.
+
+    var sqlReplace = 'replace(replace(partner_name, "_", ""), "*", "")'; //Remove any discord markdown used, without actually removing it.
+    var sqlReplaceType = 'replace(replace(type, "_", ""), "*", "")'; //Remove any discord markdown used, without actually removing it.
+
+    sql.all(`SELECT * FROM partners WHERE ${sqlReplace} LIKE ?`, [name.toLowerCase()]).then(rows => {
+        // Already a partner called that, let the user know
+        if (rows.length > 0) return message.channel.send(getErrorEmbed(serverInfo, `There is already a Partner called ${name}!`));
+
+        sql.all(`SELECT * FROM partner_types WHERE ${sqlReplaceType} LIKE ?`, [type.toLowerCase()]).then(rowsType => {
+            if(rowsType.length == 0){
+                // Need to add the type
+                var subheading = {messages: [ {type: "text", content: type} ] };
+                sql.run(`INSERT INTO partner_types(id,type,json_data) VALUES (null, ?, ?)`, [type, JSON.stringify(subheading)])
+                .then(res => {
+                    addPartnerInsert(client, serverInfo, sql, message, args, type, name).then(() => {
+                        resolve("Success");
+                    }).catch(err => { return message.channel.send(getErrorEmbed(serverInfo, err)); });
+                }).catch(err => { return message.channel.send(getErrorEmbed(serverInfo, err)); });
+            }else{
+                // Type exists
+                addPartnerInsert(client, serverInfo, sql, message, args, type, name).then(() => {
+                    resolve("Success");
+                }).catch(err => { return message.channel.send(getErrorEmbed(serverInfo, err)); });
+            }
+        
+
+            
+        }).catch(err => { return message.channel.send(getErrorEmbed(serverInfo, err)); });
+    }).catch(err => { return message.channel.send(getErrorEmbed(serverInfo, err)); });
+}
+
+function addPartnerInsert(client, serverInfo, sql, message, args, type, name){
+    return new Promise((resolve, reject) => {
+        // Partner doesn't exist, parse the channel data, and delete messages
+        parseChannelToObject(client, message).then(data => {
+            var message_data = data;
+            var header_data = { messages: [{ type: "text", content: name }] };
+
+            // Insert new partner, ids are set to 0 for now so we know this is the new partner (doesn't have a message id yet so need one we know wont be used ever)
+            // We don't use 0 as the id, since in this table, the channel header message itself is id=0, so we can get it at channel update time.
+            sql.run(`INSERT INTO partners(id,message_data,type,partner_name,header_data,enabled) VALUES (1,?,?,?,?,1)`, [JSON.stringify(message_data), type, name, JSON.stringify(header_data)]).then(res => {
+                const embed = new Discord.MessageEmbed()
+                    .setColor([255, 140, 0])
+                    .setAuthor('Attempting to Update Partners Channel!', serverInfo.logo)
+                message.channel.send(embed)
+
+                // New partner has been added, so now call update partners and let the user know all is good.
+                updatePartnersChannel(client, sql, serverInfo, message).then(result => {
+                    allowMessages(message, serverInfo, true);
+                    const embed = new Discord.MessageEmbed()
+                        .setColor([255, 255, 0])
+                        .setAuthor('Success!', serverInfo.logo)
+                        .setDescription('Added new Partner and Updated Partners Channel!')
+                    return message.channel.send(embed)
+                }).catch(err => {
+                    allowMessages(message, serverInfo, true);
+                    return message.channel.send(getErrorEmbed(serverInfo, err));
+                });
+            }).catch(err => { return message.channel.send(getErrorEmbed(serverInfo, err)); });
+        }).catch(err => { return message.channel.send(getErrorEmbed(serverInfo, err)); });
+    });
+}
+
+function addType(client, serverInfo, sql, message, args) {
+    // Check args length
+    // Usage: !partner addtype <partner_type> <subheading_text>
+    // json_data Format: {messages: [type:"text", content: <subheading_text>]}
+    // Can only have a singular message, so no need to worry, just join args 4+
+    // Needs to update partners channel
+
+    if (args.length < 4) return message.channel.send(getErrorEmbed(serverInfo, "Incorrect Usage: `!partner addType <partner_type> <subheadding_text>"));
+    
+    var type = args[2].toLowerCase();
+    var subheading = {messages: [ {type: "text", content: args.slice(3).join(" ")} ] };
+    var sqlReplace = 'replace(replace(type, "_", ""), "*", "")'; //Remove any discord markdown used, without actually removing it.
+
+    sql.all(`SELECT * FROM partner_types WHERE ${sqlReplace} LIKE ?`, [type.toLowerCase()]).then(rows => {
+        if(rows.length > 0) return message.channel.send(getErrorEmbed(serverInfo, `There is already a type called ${type}`));
+
+        // No type called this yet
+
+        sql.run(`INSERT INTO partner_types(id,type,json_data) VALUES (null, ?, ?)`, [type, JSON.stringify(subheading)]).then(res => {
+
+            // Type added, update partners channel
+            const embed = new Discord.MessageEmbed()
+                .setColor([255, 255, 0])
+                .setAuthor('Success!', serverInfo.logo)
+                .setDescription('Type added, attempting to Update Partners Channel!')
+            message.channel.send(embed)
+
+            // New partner has been added, so now call update partners and let the user know all is good.
+            updatePartnersChannel(client, sql, serverInfo, message).then(result => {
+                allowMessages(message, serverInfo, true);
+                const embed = new Discord.MessageEmbed()
+                    .setColor([255, 255, 0])
+                    .setAuthor('Success!', serverInfo.logo)
+                    .setDescription('Updated Partners Channel!')
+                return message.channel.send(embed)
+            }).catch(err => {
+                allowMessages(message, serverInfo, true);
+                return message.channel.send(getErrorEmbed(serverInfo, err));
+            });
+        }).catch(err => { return message.channel.send(getErrorEmbed(serverInfo, err)); });
+    }).catch(err => { return message.channel.send(getErrorEmbed(serverInfo, err)); });
+}
+
+function enablePartner(client, serverInfo, sql, message, args) {
+    // Needs to update partners channel
+    // Usage: !partner enable <partner_name>
+    // Min Args = 3;
+
+    if(args.length < 3) return message.channel.send(getErrorEmbed(serverInfo, "Incorrect Usage: `!partner enable <partner_name>`"));
+
+    var name = args.slice(2).join(" ");
+    var sqlReplace = 'replace(replace(partner_name, "_", ""), "*", "")';
+
+    sql.all(`SELECT * FROM partners WHERE ${sqlReplace} LIKE ?`, [name.toLowerCase()]).then(rows => {
+        if(rows.length < 1) return message.channel.send(getErrorEmbed(serverInfo, `${name} is not a Partner!`));
+
+        sql.run(`UPDATE partners SET enabled=1 WHERE ${sqlReplace} LIKE ?`, [name.toLowerCase()]).then(res => {
+            const embed = new Discord.MessageEmbed()
+                .setColor([255, 255, 0])
+                .setAuthor('Success!', serverInfo.logo)
+                .setDescription(`Enabled ${name}! Attempting to update Partners Channel!`)
+            message.channel.send(embed)
+
+            updatePartnersChannel(client, sql, serverInfo, message).then(result => {
+                allowMessages(message, serverInfo, true);
+                const embed = new Discord.MessageEmbed()
+                    .setColor([255, 255, 0])
+                    .setAuthor('Success!', serverInfo.logo)
+                    .setDescription('Updated Partners Channel!')
+                return message.channel.send(embed)
+            }).catch(err => {
+                allowMessages(message, serverInfo, true);
+                return message.channel.send(getErrorEmbed(serverInfo, err));
+            });
+        });
+    }).catch(err => { return message.channel.send(getErrorEmbed(serverInfo, err)); });
+}
+
+function disablePartner(client, serverInfo, sql, message, args) {
+    // Needs to update partners channel
+    // Usage: !partner disable <partner_name>
+    // Min Args = 3;
+
+    if(args.length < 3) return message.channel.send(getErrorEmbed(serverInfo, "Incorrect Usage: `!partner disable <partner_name>`"));
+
+    var name = args.slice(2).join(" ");
+    var sqlReplace = 'replace(replace(partner_name, "_", ""), "*", "")';
+
+    sql.all(`SELECT * FROM partners WHERE ${sqlReplace} LIKE ?`, [name.toLowerCase()]).then(rows => {
+        if(rows.length < 1) return message.channel.send(getErrorEmbed(serverInfo, `${name} is not a Partner!`));
+
+        sql.run(`UPDATE partners SET enabled=0 WHERE ${sqlReplace} LIKE ?`, [name.toLowerCase()]).then(res => {
+            const embed = new Discord.MessageEmbed()
+                .setColor([255, 255, 0])
+                .setAuthor('Success!', serverInfo.logo)
+                .setDescription(`Disabled ${name}! Attempting to update Partners Channel!`)
+            message.channel.send(embed)
+
+            updatePartnersChannel(client, sql, serverInfo, message).then(result => {
+                allowMessages(message, serverInfo, true);
+                const embed = new Discord.MessageEmbed()
+                    .setColor([255, 255, 0])
+                    .setAuthor('Success!', serverInfo.logo)
+                    .setDescription('Updated Partners Channel!')
+                return message.channel.send(embed)
+            }).catch(err => {
+                allowMessages(message, serverInfo, true);
+                return message.channel.send(getErrorEmbed(serverInfo, err));
+            });
+        });
+    }).catch(err => { return message.channel.send(getErrorEmbed(serverInfo, err)); });
+}
+
+function listPartners(client, serverInfo, sql, message, args) {
+    // List all partners, optionally if args 3 specified as valid enabled|disabled then filter
+    var whereClause = "WHERE id>1";
+    if(args[3] !== undefined){
+        if(args[3].toLowerCase() == "enabled") whereClause =+ " AND enabled=1";
+        else if(args[3].toLowerCase() == "disabled") whereClause =+ " AND enabled=0";
+    }
+
+    sql.all(`SELECT * FROM partners ${whereClause}`).then(rows => {
+        var allPartners = "";
+        rows.forEach(row => {
+            var en;
+            if(row.enabled == 1) en = " [Enabled]";
+            else en = " [Disabled]";
+            allPartners += "- " + row.partner_name + en + ",\n";
+        });
+        const embed = new Discord.MessageEmbed()
+            .setColor([255, 255, 0])
+            .setAuthor('AlphaConsole Partners:', serverInfo.logo)
+            .setDescription(allPartners)
+        return message.channel.send(embed);
+    }).catch(err => { return message.channel.send(getErrorEmbed(serverInfo, err)); });
+}
+
+function listTypes(client, serverInfo, sql, message, args) {
+    // List all types
+    sql.all(`SELECT * FROM partner_types`).then(rows => {
+        var allTypes = "";
+        rows.forEach(row => {
+            allTypes += "- " + row.type + ",\n";
+        });
+        const embed = new Discord.MessageEmbed()
+            .setColor([255, 255, 0])
+            .setAuthor('Partner Types:', serverInfo.logo)
+            .setDescription(allTypes)
+        return message.channel.send(embed);
+    }).catch(err => { return message.channel.send(getErrorEmbed(serverInfo, err)); });
+}
+
+function setHeader(client, serverInfo, sql, message, args){
+    // Needs to update partners channel
+    // search via LIKE args 3
+    // Args min length 3
+
+    if(args.length < 3){
+        return message.channel.send(getErrorEmbed(serverInfo, "Incorrect Usage: `!partner setHeader <partner_name>`"));
+    }
+
+    var name = args.slice(2).join(" ");
+    var sqlReplace = 'replace(replace(partner_name, "_", ""), "*", "")';
+
+    sql.all(`SELECT * FROM partners WHERE ${sqlReplace} LIKE ?`, [name.toLowerCase()]).then(async rows => {
+        if(rows.length == 0){
+            return message.channel.send(getErrorEmbed(serverInfo, `${name} is not a Partner`));
+        }
+
+        var header_data = await parseChannelToObject(client, message);
+
+        sql.run(`UPDATE partners SET header_data=? WHERE ${sqlReplace} LIKE ?`, [JSON.stringify(header_data), name.toLowerCase()]).then(() => {
+            return forceUpdatePartners(client, serverInfo, sql, message, args);
+        }).catch(err => { return message.channel.send(getErrorEmbed(serverInfo, err)); });
+    }).catch(err => { return message.channel.send(getErrorEmbed(serverInfo, err)); });
+}
+
+function setTypeHeader(client, serverInfo, sql, message, args){
+    // Needs to update partners channel
+    // search via LIKE args 3
+    // Args min length 3
+
+    if(args.length < 3){
+        return message.channel.send(getErrorEmbed(serverInfo, "Incorrect Usage: `!partner setTypeHeader <type>`"));
+    }
+
+    var type = args.slice(2).join(" ");
+    var sqlReplace = 'replace(replace(type, "_", ""), "*", "")';
+
+    sql.all(`SELECT * FROM partner_types WHERE ${sqlReplace} LIKE ?`, [type.toLowerCase()]).then(async rows => {
+        if(rows.length == 0){
+            return message.channel.send(getErrorEmbed(serverInfo, `${type} is not a Partner Type`));
+        }
+
+        var json_data = await parseChannelToObject(client, message);
+
+        sql.run(`UPDATE partner_types SET json_data=? WHERE ${sqlReplace} LIKE ?`, [JSON.stringify(json_data), type.toLowerCase()]).then(() => {
+            return forceUpdatePartners(client, serverInfo, sql, message, args);
+        }).catch(err => { return message.channel.send(getErrorEmbed(serverInfo, err)); });
+    }).catch(err => { return message.channel.send(getErrorEmbed(serverInfo, err)); });
+}
+
+async function setChannelHeader(client, serverInfo, sql, message, args){
+    // Needs to update partners channel
+    // partners table id of 0, follows same format but in header_data
+    // if id 0 doesn't exist then insert instead
+    var header_data = await parseChannelToObject(client, message);
+
+    sql.run(`REPLACE INTO partners (id,type,partner_name,message_data,header_data,enabled) VALUES (0,null,null,null,?,null)`, [JSON.stringify(header_data)]).then(res => {
+        return forceUpdatePartners(client, serverInfo, sql, message, args); // Could use this instead of every other update tbh
+    }).catch(err => { return message.channel.send(getErrorEmbed(serverInfo, err)); });
+}
+
+function forceUpdatePartners(client, serverInfo, sql, message, args){
+    // Type added, update partners channel
+    const embed = new Discord.MessageEmbed()
+        .setColor([255, 140, 0])
+        .setAuthor('Attempting to Update Partners Channel!', serverInfo.logo)
+    if(message != null) message.channel.send(embed)
+    allowMessages(message, serverInfo, false);
+
+    // New partner has been added, so now call update partners and let the user know all is good.
+    updatePartnersChannel(client, sql, serverInfo, message).then(result => {
+        //Check Promise result, since the function is running async.
+        allowMessages(message, serverInfo, true);
+        const embed = new Discord.MessageEmbed()
+            .setColor([255, 255, 0])
+            .setAuthor('Success!', serverInfo.logo)
+            .setDescription('Updated Partners Channel!')
+        return message.channel.send(embed)
+        
+    }).catch(err => {
+        allowMessages(message, serverInfo, true);
+        return message.channel.send(getErrorEmbed(serverInfo, err));
+    });
+}
+
+function allowMessages(message, serverInfo, allow){
+    if(message == null) return;
+    message.guild.channels.get(serverInfo.editPartnerChannel).overwritePermissions(message.guild.id, {
+        SEND_MESSAGES: allow
+    });
+}
+
+function getErrorEmbed(serverInfo, err){
+    const embed = new Discord.MessageEmbed()
+        .setColor([255, 0, 0])
+        .setAuthor('Failed!', serverInfo.logo)
+        .addField("Error:", `${err}`)
+        //.addField("Caller:", `${getErrorEmbed.caller}`)
+    return embed
+}
+
+
+/**
+ * Parse the previous messages into a the object format used.
+ * @param {*} client 
+ * @param {*} message 
+ */
+async function parseChannelToObject(client, message) {
+    return new Promise((resolve, reject) => {
+        message.channel.messages.fetch({ limit: amount })
+            .then(collectedMessages => {
+                // All good in the hood format this boi
+                var data = {};
+                var messages = [];
+                var mesArray = Array.from(collectedMessages.values());
+                // Run through in reverse order so that we can remove messages without running into issues looking for nonexistent messages
+                for (var i = (mesArray.length - 1); i >= 0; i--) {
+                    var cmessage = mesArray[i];
+
+                    // Check if this message has file and text together
+                    if (cmessage.attachments !== undefined && Array.from(cmessage.attachments).length > 0 && cmessage.content !== undefined && cmessage.content.length > 0 && !message.author.bot) {
+                        var messageHybrid = {};
+                        var att = Array.from(cmessage.attachments);
+                        messageHybrid.type = "hybrid";
+                        messageHybrid.url = att[0][1].url;
+                        messageHybrid.content = cmessage.content;
+                        messages.push(messageHybrid);
+                        // Delete this message because it's done
+                        cmessage.delete(1000);
+                    }
+
+                    // Check if this message has a file only
+                    else if (cmessage.attachments !== undefined && Array.from(cmessage.attachments).length > 0 && !message.author.bot) {
+                        var messageImage = {};
+                        var att = Array.from(cmessage.attachments);
+                        messageImage.type = "file";
+                        messageImage.url = att[0][1].url;
+                        messages.push(messageImage);
+                        // Delete this message because it's done
+                        cmessage.delete(1000);
+                    }
+
+                    // Check if this message has text only
+                    else if (cmessage.content !== undefined && cmessage.content.length > 0 && !cmessage.author.bot && cmessage.content.toLowerCase().indexOf("!partner") == -1) {
+                        var messageText = {};
+                        messageText.type = "text";
+                        messageText.content = cmessage.content;
+                        messages.push(messageText);
+                        // Delete this message because it's done
+                        cmessage.delete(1000);
+
+                    }
+
+                    // Cannot put delete message here, since if command message isn't deleted quick enough, it will cause the promise to fail
+                }
+                data.messages = messages;
+                resolve(data);
+            }).catch(err => reject(err));
+    });
+}
+
+
+/**
+ * Update the Partners List Channel.
+ * @param {*} client 
+ * @param {*} sql 
+ * @param {*} serverInfo 
+ * @param {*} message 
+ */
+async function updatePartnersChannel(client, sql, serverInfo, message) {
+    var partnerChannel = message.guild.channels.get(serverInfo.partnerChannel);
+    allowMessages(message, serverInfo, false);
+    return new Promise(function(resolve, reject){
+        // DELETE ALL MESSAGES
+        partnerChannel.messages.fetch({ limit: 100 })
+        .then(fetched => {
+            partnerChannel.bulkDelete(fetched, true)
+            .then(deletedMessages => {
+
+
+                var update_messages_holder = {};
+                update_messages_holder.messages = [];
+
+
+                // All messages deleted, send channel headers
+                sql.get("SELECT * FROM partners WHERE id=?", [0]).then(async row => {
+                    //Should protect against initial run with no data
+                    if(row == undefined) row = {header_data: ""};
+                    //Make sure channel headers is showing something
+                    var channelData;
+                    if(row.header_data == null || row.header_data == "{}" || row.header_data == "") channelData = { messages: [{type: "text", content:"No header has been set yet. Please set one."}]};
+                    else channelData = JSON.parse(row.header_data);
+
+                    // Add channel headers to holder
+                    for(var i = 0; i < channelData.messages.length; i++){
+                        var mm = channelData.messages[i];
+                        update_messages_holder.messages.push({type: mm.type, content: mm.content, url: mm.url, react: false});
+                    }
+
+
+                        // For each partner type
+                        sql.all(`SELECT * FROM partner_types`).then(rowsType => {
+                            var doneTypes = 0;
+
+                            if(rowsType.length == 0){
+                                // There are no partner types to show :/
+                                update_messages_holder.messages.push({type: "text", content: "_**We don't have any partners right now!**_", url: undefined, react: false});
+                                sendMessages(partnerChannel, update_messages_holder, serverInfo, sql).then(()=> {
+                                    resolve("Success!");
+                                }).catch(err => { reject(err) });
+                            }
+
+                            rowsType.forEach(rowType => {
+                                var typeData = JSON.parse(rowType.json_data);
+                                // Get all partners in this type
+                                sql.all(`SELECT * FROM partners WHERE type=? AND enabled=1`, [rowType.type]).then(rows => {
+                                    // For each partner
+                                    var doneRows = 0;
+
+
+                                    // Check if there are any partners, if there are add header for this type
+                                    if(rows.length > 0){
+                                        for(var i = 0; i < typeData.messages.length; i++){
+                                            var mm = typeData.messages[i];
+                                            update_messages_holder.messages.push({type: mm.type, content: mm.content, url: mm.url, react: false});
+                                        }
+                                    }
+
+
+                                    // No partners so type is done
+                                    else doneTypes++;
+                                    if(doneTypes == rowsType.length){
+                                        // All of the types have been looped through
+                                        sendMessages(partnerChannel, update_messages_holder, serverInfo, sql).then(()=> {
+                                            resolve("Success!");
+                                        }).catch(err => { reject(err) });
+                                    }
+
+                                    rows.forEach(rowPartner => {
+                                        // add the message, and add reaction.
+
+                                        var partnerData = JSON.parse(rowPartner.header_data);
+
+                                        var mm = partnerData.messages[0];
+                                        update_messages_holder.messages.push({type: mm.type, content: mm.content, url: mm.url, react: true, id: '' + rowPartner.id});
+                                        
+
+                                        doneRows++; // Partner done
+
+                                        if(doneRows == rows.length){
+                                            // All of the partners for this type have been looped through
+                                            doneTypes++; // Type done
+
+                                            update_messages_holder.messages.push({type: "file", url: "https://cdn.discordapp.com/attachments/413018013281943554/413351571812777984/ACBorderUpdated.png", react: false});
+
+                                            if(doneTypes == rowsType.length){
+                                                // All of the types have been looped through
+                                                sendMessages(partnerChannel, update_messages_holder, serverInfo, sql).then(()=> {
+                                                    resolve("Success!");
+                                                }).catch(err => { reject(err) });
+                                            }
+                                        }
+                                    });
+                                }).catch(err => reject(err));
+                            });
+                        }).catch(err => reject(err));
+                    });
+                }).catch(err => reject(err));
+            }).catch(err => reject(err));
+    });
+}
+
+function sendMessages(partnerChannel, data, serverInfo, sql) {
+    // format fo messages {type: "", content: "", url: "", react: bool, id: ""}
+    // if react then is partner message, and update db to new message id where message.id
+    let emoji = serverInfo.partnerEmoji;
+
+    return new Promise((resolve, reject) => {
+        var chain = Promise.resolve();
+
+        for(let message of data.messages){
+            chain = chain.then(() => {
+                switch (message.type) {
+                    case "hybrid":
+                        return partnerChannel.send(message.content, { files: [message.url] })
+                        .then(newMessage => {
+                            if(message.react){
+                                sql.run(`UPDATE partners SET id=? WHERE id=?`, ['' + newMessage.id, '' + message.id]).then(() =>{ newMessage.react(emoji); })
+                                .catch(err => {partnerChannel.guild.channels.get(serverInfo.editPartnerChannel).send(getErrorEmbed(serverInfo, err));});
+                            }
+                        }).catch(err => { return partnerChannel.guild.channels.get(serverInfo.editPartnerChannel).send(getErrorEmbed(serverInfo, err)); });
+                    case "file":
+                        return partnerChannel.send("", { files: [message.url] })
+                        .then(newMessage => {
+                            if(message.react){
+                                sql.run(`UPDATE partners SET id=? WHERE id=?`, [''+newMessage.id, ''+message.id]).then(() =>{ newMessage.react(emoji); })
+                                .catch(err => {partnerChannel.guild.channels.get(serverInfo.editPartnerChannel).send(getErrorEmbed(serverInfo, err));});
+                            }
+                        }).catch(err => { return partnerChannel.guild.channels.get(serverInfo.editPartnerChannel).send(getErrorEmbed(serverInfo, err)); });
+                    case "text":
+                        return partnerChannel.send(message.content)
+                        .then(newMessage => {
+                            if(message.react){
+                                sql.run(`UPDATE partners SET id=? WHERE id=?`, [''+newMessage.id, ''+message.id]).then(() =>{ newMessage.react(emoji); })
+                                .catch(err => {partnerChannel.guild.channels.get(serverInfo.editPartnerChannel).send(getErrorEmbed(serverInfo, err));});
+                            }
+                        }).catch(err => { return partnerChannel.guild.channels.get(serverInfo.editPartnerChannel).send(getErrorEmbed(serverInfo, err)); });
+                    default:
+                        return partnerChannel.guild.channels.get(serverInfo.editPartnerChannel).send(getErrorEmbed(serverInfo, `The message type ${message.type} is invalid!`));
+                }
+            });
+        }
+        chain = chain.then(resolve()).catch(err => reject(err));
+    }); 
+}
+
+//Functions used to check if a player has the desired role
+function pluck(array) {
+    return array.map(function (item) { return item["name"]; });
+}
+function hasRole(mem, role) {
+    if (pluck(mem.roles).includes(role)) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
+function mysql_real_escape_string(str) {
+    return str.replace(/[\0\x08\x09\x1a\n\r"'\\\%]/g, function (char) {
+        switch (char) {
+            case "\0":
+                return "\\0";
+            case "\x08":
+                return "\\b";
+            case "\x09":
+                return "\\t";
+            case "\x1a":
+                return "\\z";
+            case "\n":
+                return "\\n";
+            case "\r":
+                return "\\r";
+            case "\"":
+            case "'":
+            case "\\":
+            case "%":
+                return char + char; // prepends a backslash to backslash, percent,
+            // and double/single quotes
+        }
+    });
+}

--- a/src/events/messageReactionAdd.js
+++ b/src/events/messageReactionAdd.js
@@ -4,7 +4,7 @@ module.exports = {
     title: "messageReactionAdd",
     description: "Event when a new reaction has been added for like `#Showcase` & `#Suggestions`",
     
-    run: async(client, serverInfo, reaction, user) => {
+    run: async(client, serverInfo, reaction, user, sql) => {
     
         if (reaction._emoji.name == "❌") {
             if (hasRole(client.guilds.get(serverInfo.guildId).members.get(user.id), "Developer") || hasRole(client.guilds.get(serverInfo.guildId).members.get(user.id), "Admin")) {
@@ -52,9 +52,76 @@ module.exports = {
     
                 }
             }
+        }else if(reaction._emoji.id == serverInfo.partnerEmoji){
+            // ADDED FOR MESSAGING USER THE PARTNER INFORMATIONS
+            if(reaction.message.channel.id == serverInfo.partnerChannel && !user.bot){
+                // Reacted to message, remove reaction, send messages
+                reaction.users.remove(user);
+
+                var canMessage = await partnerCanMessage(client, user, reaction.message);
+                var errChannel = reaction.message.guild.channels.get(serverInfo.modlogChannel);
+
+                if(canMessage){
+                    sql.get(`SELECT * FROM partners WHERE id=?`, [reaction.message.id]).then(row => {
+                        var data = JSON.parse(row.message_data);
+                        sendMessages(user, data, serverInfo, sql, errChannel);
+                    }).catch(err => {
+                        const embed = new Discord.MessageEmbed()
+                            .setColor([255, 0, 0])
+                            .setAuthor("Partner Database Error", serverInfo.logo)
+                            .setDescription("Something has gone wrong getting the 'message_data' from the 'partners' table. That's all I know.")
+                            .addField("Error:", `${err}`)
+                        return errChannel.send(embed);
+                    });
+                }else{
+                    // Send to bot spam message about user being unable to receive PMs
+                    reaction.message.guild.channels.get(serverInfo.BotSpam).send(`${reaction.message.member}, your DM's are disabled, so we can't send you the information you requested about one of our Partners!`);
+                }
+            }
         }
     }
 }
+
+async function partnerCanMessage(client, user, message){
+    // Little bit of a weird way to check if it can message, but if it's not done this way, then sending messages in order would cause 'n' amount of bot-spam messages
+    // to the user :/
+
+    return new Promise((resolve, reject) => {
+        user.send("**Hello! Here is the information you requested about one of our partners!**").then(() => {
+            resolve(true);
+        }).catch(err => {
+            resolve(false);
+        });
+    });
+}
+
+function sendMessages(user, data, serverInfo, sql, errChannel) {
+    // format fo messages {type: "", content: "", url: "", react: bool, id: ""}
+    // if react then is partner message, and update db to new message id where message.id
+
+    return new Promise((resolve, reject) => {
+        var chain = Promise.resolve();
+        for(let message of data.messages){
+            chain = chain.then(() => {
+                switch (message.type) {
+                    case "hybrid":
+                        return user.send(message.content, { files: [message.url] })
+                        .catch(err => { return errChannel.send(getErrorEmbed(serverInfo, err)); });
+                    case "file":
+                        return user.send("", { files: [message.url] })
+                        .catch(err => { return errChannel.send(getErrorEmbed(serverInfo, err)); });
+                    case "text":
+                        return user.send(message.content)
+                        .catch(err => { return errChannel.send(getErrorEmbed(serverInfo, err)); });
+                    default:
+                        reject("A Message Type error has occurred. Please contact an AlphaConsole Admin!");
+                }
+            });
+        }
+        chain = chain.then(resolve()).catch(err => reject(err));
+    }); 
+}
+
 
 //Functions used to check if a player has the desired role
 function pluck(array) {

--- a/src/events/updatePartners.js
+++ b/src/events/updatePartners.js
@@ -1,0 +1,160 @@
+const Discord = require('discord.js');
+
+module.exports = {
+    title: "update partners",
+    description: "Resend messages into the partners channel, otherwise reactions aren't checked against noncached messages.",
+
+    run: async(client, serverInfo, sql) => {
+
+    var partnerChannel = client.guilds.get(serverInfo.guildId).channels.get(serverInfo.partnerChannel);
+    return new Promise(function(resolve, reject){
+        // DELETE ALL MESSAGES
+        partnerChannel.messages.fetch({ limit: 100 })
+        .then(fetched => {
+            partnerChannel.bulkDelete(fetched, true)
+            .then(deletedMessages => {
+
+                var update_messages_holder = {};
+                update_messages_holder.messages = [];
+
+                // All messages deleted, send channel headers
+                sql.get("SELECT * FROM partners WHERE id=?", [0]).then(async row => {
+                    //Should protect against initial run with no data
+                    if(row == undefined) row = {header_data: ""};
+                    //Make sure channel headers is showing something
+                    var channelData;
+                    if(row.header_data == null || row.header_data == "{}" || row.header_data == "") channelData = { messages: [{type: "text", content:"No header has been set yet. Please set one."}]};
+                    else channelData = JSON.parse(row.header_data);
+
+                    // Add channel headers to holder
+                    for(var i = 0; i < channelData.messages.length; i++){
+                        var mm = channelData.messages[i];
+                        update_messages_holder.messages.push({type: mm.type, content: mm.content, url: mm.url, react: false});
+                    }
+
+
+                        // For each partner type
+                        sql.all(`SELECT * FROM partner_types`).then(rowsType => {
+                            var doneTypes = 0;
+
+                            if(rowsType.length == 0){
+                                // There are no partner types to show :/
+                                update_messages_holder.messages.push({type: "text", content: "_**We don't have any partners right now!**_", url: undefined, react: false});
+                                sendMessages(partnerChannel, update_messages_holder, serverInfo, sql).then(()=> {
+                                    resolve("Success!");
+                                }).catch(err => { reject(err) });
+                            }
+
+                            rowsType.forEach(rowType => {
+                                var typeData = JSON.parse(rowType.json_data);
+                                // Get all partners in this type
+                                sql.all(`SELECT * FROM partners WHERE type=? AND enabled=1`, [rowType.type]).then(rows => {
+                                    // For each partner
+                                    var doneRows = 0;
+
+
+                                    // Check if there are any partners, if there are add header for this type
+                                    if(rows.length > 0){
+                                        for(var i = 0; i < typeData.messages.length; i++){
+                                            var mm = typeData.messages[i];
+                                            update_messages_holder.messages.push({type: mm.type, content: mm.content, url: mm.url, react: false});
+                                        }
+                                    }
+
+
+                                    // No partners so type is done
+                                    else doneTypes++;
+                                    if(doneTypes == rowsType.length){
+                                        // All of the types have been looped through
+                                        sendMessages(partnerChannel, update_messages_holder, serverInfo, sql).then(()=> {
+                                            resolve("Success!");
+                                        }).catch(err => { reject(err) });
+                                    }
+
+                                    rows.forEach(rowPartner => {
+                                        // add the message, and add reaction.
+
+                                        var partnerData = JSON.parse(rowPartner.header_data);
+
+                                        for(var i = 0; i < partnerData.messages.length; i++){
+                                            var mm = partnerData.messages[i];
+                                            update_messages_holder.messages.push({type: mm.type, content: mm.content, url: mm.url, react: true, id: '' + rowPartner.id});
+                                        }
+
+                                        doneRows++; // Partner done
+
+                                        if(doneRows == rows.length){
+                                            // All of the partners for this type have been looped through
+                                            doneTypes++; // Type done
+
+                                            update_messages_holder.messages.push({type: "file", url: "https://cdn.discordapp.com/attachments/413018013281943554/413351571812777984/ACBorderUpdated.png", react: false});
+
+                                            if(doneTypes == rowsType.length){
+                                                // All of the types have been looped through
+                                                sendMessages(partnerChannel, update_messages_holder, serverInfo, sql).then(()=> {
+                                                    resolve("Success!");
+                                                }).catch(err => { reject(err) });
+                                            }
+                                        }
+                                    });
+                                }).catch(err => reject(err));
+                            });
+                        }).catch(err => reject(err));
+                    });
+                }).catch(err => reject(err));
+            }).catch(err => reject(err));
+    });
+    }
+}
+
+function sendMessages(partnerChannel, data, serverInfo, sql) {
+    // format fo messages {type: "", content: "", url: "", react: bool, id: ""}
+    // if react then is partner message, and update db to new message id where message.id
+    let emoji = serverInfo.partnerEmoji;
+    return new Promise((resolve, reject) => {
+        var chain = Promise.resolve();
+
+        for(let message of data.messages){
+            chain = chain.then(() => {
+                switch (message.type) {
+                    case "hybrid":
+                        return partnerChannel.send(message.content, { files: [message.url] })
+                        .then(newMessage => {
+                            if(message.react){
+                                sql.run(`UPDATE partners SET id=? WHERE id=?`, ['' + newMessage.id, '' + message.id]).then(() =>{ newMessage.react(emoji); })
+                                .catch(err => {partnerChannel.guild.channels.get(serverInfo.editPartnerChannel).send(getErrorEmbed(serverInfo, err));});
+                            }
+                        }).catch(err => { return partnerChannel.guild.channels.get(serverInfo.editPartnerChannel).send(getErrorEmbed(serverInfo, err)); });
+                    case "file":
+                        return partnerChannel.send("", { files: [message.url] })
+                        .then(newMessage => {
+                            if(message.react){
+                                sql.run(`UPDATE partners SET id=? WHERE id=?`, [''+newMessage.id, ''+message.id]).then(() =>{ newMessage.react(emoji); })
+                                .catch(err => {partnerChannel.guild.channels.get(serverInfo.editPartnerChannel).send(getErrorEmbed(serverInfo, err));});
+                            }
+                        }).catch(err => { return partnerChannel.guild.channels.get(serverInfo.editPartnerChannel).send(getErrorEmbed(serverInfo, err)); });
+                    case "text":
+                        return partnerChannel.send(message.content)
+                        .then(newMessage => {
+                            if(message.react){
+                                sql.run(`UPDATE partners SET id=? WHERE id=?`, [''+newMessage.id, ''+message.id]).then(() =>{ newMessage.react(emoji); })
+                                .catch(err => {partnerChannel.guild.channels.get(serverInfo.editPartnerChannel).send(getErrorEmbed(serverInfo, err));});
+                            }
+                        }).catch(err => { return partnerChannel.guild.channels.get(serverInfo.editPartnerChannel).send(getErrorEmbed(serverInfo, err)); });
+                    default:
+                        return partnerChannel.guild.channels.get(serverInfo.editPartnerChannel).send(getErrorEmbed(serverInfo, `The message type ${message.type} is invalid!`));
+                }
+            });
+        }
+        chain = chain.then(resolve()).catch(err => reject(err));
+    }); 
+}
+
+function getErrorEmbed(serverInfo, err){
+    const embed = new Discord.MessageEmbed()
+        .setColor([255, 0, 0])
+        .setAuthor('Failed!', serverInfo.logo)
+        .addField("Error:", `${err}`)
+        //.addField("Caller:", `${getErrorEmbed.caller}`)
+    return embed
+}


### PR DESCRIPTION
Initial Partners feature working and tested.

Commands for adding DB tables:

> CREATE TABLE \`partner_types\` ( \`id\` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, \`type\` TEXT NOT NULL, \`json_data\` TEXT NOT NULL )

> CREATE TABLE \`partners\` ( \`id\` TEXT NOT NULL UNIQUE, \`type\` TEXT, \`partner_name\` TEXT, \`message_data\` TEXT, \`header_data\` TEXT, \`enabled\` INTEGER )

Lines to add to serverInfo.js

> editPartnerChannel: 'id here', // Channel for !partner command
> partnerChannel: 'id here', // Channel bot uses to list the partners, and watch their respective reactions
> partnerEmoji: 'emoji id here' // Emoji used for partner reactions


Issue: #112 

It is a little difficult to understand at first, but feel free to ask me anything about it.