### PR TITLE
Title rotation fix

### DIFF
--- a/src/cmds/titles.js
+++ b/src/cmds/titles.js
@@ -28,7 +28,7 @@ module.exports = {
 
 function setTitle(client, serverInfo, message, blackListedWords, args) {
     var userTitle = createTitle(message, args, 2); //make title
-    if (userTitle.replace(/[^::]/g, "").length > 5) {
+    if (userTitle.replace(/[^::]/g, "").length > 10) {
         message.author.send('AlphaConsole does not support more than 5 rotations in your custom title. Please try again.').catch(e => message.guild.channels.get(serverInfo.BotSpam).send(`${message.member}, your DM's are disabled and we were not able to send you information through DM.`))
     } else {
         var invalidTitle = isValidTitle(message, blackListedWords, userTitle); //check if title is valid

--- a/src/cmds/titles.js
+++ b/src/cmds/titles.js
@@ -28,7 +28,7 @@ module.exports = {
 
 function setTitle(client, serverInfo, message, blackListedWords, args) {
     var userTitle = createTitle(message, args, 2); //make title
-    if (userTitle.replace(/[^::]/g, "").length > 10) {
+    if (userTitle.replace(/[^::]/g, "").length > 8) {
         message.author.send('AlphaConsole does not support more than 5 rotations in your custom title. Please try again.').catch(e => message.guild.channels.get(serverInfo.BotSpam).send(`${message.member}, your DM's are disabled and we were not able to send you information through DM.`))
     } else {
         var invalidTitle = isValidTitle(message, blackListedWords, userTitle); //check if title is valid


### PR DESCRIPTION
Was set to 5 in length, so 3 rotations worked fine because only "first title :: second :: third" is only 4x : 

Regex was replacing leaving only : and was checking length for more than 5, since it's :: for title splitting it should have been 10 (because 5x2 is 10 - I think)

EDIT: I did some more thinking and it turns out that `one::two::three::four::five` is only 8, not 10. :barbocide: